### PR TITLE
Don't remove '-std=gnu99' option

### DIFF
--- a/builder/MyBuilder.pm
+++ b/builder/MyBuilder.pm
@@ -32,7 +32,7 @@ sub ACTION_code {
     my @libs = <vendor/mruby/lib/*>;
     if (@libs <= 0) {
         my $guard = Cwd::Guard::cwd_guard('vendor/mruby/');
-        system(q{make CFLAGS="-g -fPIC"}) == 0
+        system(q{make CFLAGS="-std=gnu99 -g -fPIC"}) == 0
             or die;
     }
 


### PR DESCRIPTION
Some mrbgems cannot be built without this option with GCC, because GCC 4.9 or lower version use `-std=gnu89` as default. `-std=gnu99` is available on both GCC and Clang.  (Clang has no problem, because old Clang uses `-std=gnu99` as default and recent Clang uses `-std=gnu11` as default).

Please see this line
- https://github.com/mruby/mruby/blob/058dc7bd41bbe546eef6a6860c9ae3192f510424/tasks/toolchains/gcc.rake#L4
