### PR TITLE
Specify '-std=c99' explicitly for older GCC

### DIFF
--- a/builder/MyBuilder.pm
+++ b/builder/MyBuilder.pm
@@ -20,7 +20,7 @@ sub new {
         exit 0;
     }
 
-    $args{extra_compiler_flags} = ['-fPIC', '-I' . File::Spec->rel2abs('vendor/mruby/include')];
+    $args{extra_compiler_flags} = ['-std=c99', '-fPIC', '-I' . File::Spec->rel2abs('vendor/mruby/include')];
     $args{extra_linker_flags}   = ['-L' . File::Spec->rel2abs('vendor/mruby/build/host/lib'), '-lmruby'];
 
     return $self->SUPER::new(%args);


### PR DESCRIPTION
workaroundではありますが, 明示的に `-std=c99`を与えるようにしました.
(Module::Build::XSUtilを修正するのが望ましいと思いますが, そのためには Devel::CheckCompilerも修正する必要があると思います)

本パッケージは `Module::Build::XSUtil`の `needs_compiler_c99`により, C99の機能が実装されるコンパイラが利用できるかチェックされます. しかしこのチェックは十分でなく, `-std=gnu89`でもチェックを通ってしまいます. この `gnu89`というのは C89の GNU版(方言)です. これにはいくつかの C99の機能が含まれます. 例えば, c99で定義されたヘッダファイルが読み込めることや, 変数宣言が関数の冒頭になくてもよい, などです. パッケージ内で使用する C99の機能が, すべて `gnu89`に収まるのであれば問題ないのですが, このパッケージでは `gnu89`ではエラーとなる c99の機能が利用されています. それが下記の箇所で使用される `for`ループの初期化部での変数宣言です. 

https://github.com/tokuhirom/mRuby.pm/blob/a61fa737d53227bbee466965a78c6ed63524206f/lib/mRuby.xs#L55

これは `gnu89`ではサポートされておらず, `-std=c99`, `-std=gnu99`等をつけないとコンパイルエラーとなります.

以下のような変更を加え, `gnu89`でもビルドを通るようにするという手も考えられます.

``` diff
diff --git a/lib/mRuby.xs b/lib/mRuby.xs
index 9401364..9b9dd16 100644
--- a/lib/mRuby.xs
+++ b/lib/mRuby.xs
@@ -50,9 +50,10 @@ funcall(mrb_state *mrb, SV* funcname, ...)
         const char*   funcname_p   = SvPV(funcname, len);
         const mrb_sym funcname_sym = mrb_intern(mrb, funcname_p, (size_t)len);
         const mrb_int argc         = (mrb_int)items - 2;
+        int i;

         mrb_value *argv; Newxc(argv, argc, mrb_value, mrb_value);
-        for (int i = 0; LIKELY(i<argc); i++) {
+        for (i = 0; LIKELY(i<argc); i++) {
             SV *arg = ST(i+2);
             argv[i] = mruby_pm_bridge_sv2value(aTHX_ mrb, arg);
         }
```

なお GCC 5以上(デフォルトが `gnu89`から `gnu11`になった), Clang(出た当時からデフォルトが `gnu99`, 新しいバージョンだと `gnu11`)では本件は問題になりません.
