### PR TITLE
configure requires Cwd::Guard

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -19,6 +19,7 @@ my %args = (
 
     configure_requires => {
         'Module::Build' => '0.4005',
+        'Cwd::Guard'    => 0,
     },
 
     name            => 'mRuby',


### PR DESCRIPTION
Without this I got

```
Configuring mRuby-0.11 ... Can't locate Cwd/Guard.pm in @INC (you may need to install the Cwd::Guard module) (@INC contains: /home/ollisg/.perlbrew/libs/perl-5.23.4tc@dev/lib/perl5/x86_64-linux-thread-multi /home/ollisg/.perlbrew/libs/perl-5.23.4tc@dev/lib/perl5 /home/ollisg/perl5/perlbrew/perls/perl-5.23.4tc/lib/site_perl/5.23.4/x86_64-linux-thread-multi /home/ollisg/perl5/perlbrew/perls/perl-5.23.4tc/lib/site_perl/5.23.4 /home/ollisg/perl5/perlbrew/perls/perl-5.23.4tc/lib/5.23.4/x86_64-linux-thread-multi /home/ollisg/perl5/perlbrew/perls/perl-5.23.4tc/lib/5.23.4 .) at builder/MyBuilder.pm line 6.
BEGIN failed--compilation aborted at builder/MyBuilder.pm line 6.
Compilation failed in require at Build.PL line 12.
BEGIN failed--compilation aborted at Build.PL line 12.
N/A
! Configure failed for mRuby-0.11. See /home/ollisg/.cpanm/work/1453221943.6731/build.log for details.
Expiring 9 work directories.
2 distributions installed
```
